### PR TITLE
API endpoint changed when overriding sc-parameter's matcher and value

### DIFF
--- a/satapi/satapilib/puppet_classes.py
+++ b/satapi/satapilib/puppet_classes.py
@@ -43,6 +43,12 @@ class SatAPIPuppetClasses(SatAPIConnection):
                             Parameter + '/override_values', JSONData)
         return Response
 
+    # Get smart class parameters id for a given search criteria
+    def searchPuppetClassSmartParameterID(self, criteria, PuppetClass):
+        Response=self.GET(self.SatAPILocation + 'puppetclasses/' + PuppetClass +
+                         '/smart_class_parameters?search=key=' + criteria)
+        return Response
+
     # Set/update override values for a given class parameter
     def setPuppetClassSmartParameterOverrides(self, PuppetClass,
         Parameter, OverridesJSON):


### PR DESCRIPTION
This PR solves issues found in #11 when checking API changes on Satellite 6.3.

Basically, setPuppetClassSmartParameterOverrides was using a non-documented API endpoint:

`api/v2/puppetclasses/:id_class/smart_class_parameters/:id_parameter/override_values`

which changed. Now two API calls are needed:

1. Get the ID of the sc-parameter to be updated

GET /api/environments/:environment_id/puppetclasses/:puppetclass_id/smart_class_parameters     

> List of smart class parameters for a specific environment/Puppet class combination

2. Once we have the sc-parameters' ID we can modify or add a new matcher/value using the following API endpoint:

PUT /api/smart_class_parameters/:smart_class_parameter_id/override_values/:id  

> Update an override value for a specific smart class parameter


Another important point is that setPuppetClassSmartParameterOverrides now expects a **JSON containing a single override_value element** instead of an array of elements.  This override_value element contains a matcher and value with new or updated information.


